### PR TITLE
Tutorial not working - can't find provider for capability

### DIFF
--- a/src/capabilities/discovery.py
+++ b/src/capabilities/discovery.py
@@ -292,6 +292,7 @@ class SpecIndex(object):
         :raises: :py:exc:`DuplicateNameException` if there is a name collision
         """
         interface_name = '{package}/{name}'.format(package=package_name, name=interface.name)
+        interface.name = interface_name
         if interface_name in self.names:
             raise DuplicateNameException(
                 interface_name, package_name,
@@ -320,6 +321,7 @@ class SpecIndex(object):
             this semantic capability interface redefines is not found.
         """
         semantic_interface_name = '{package}/{name}'.format(package=package_name, name=semantic_interface.name)
+        semantic_interface.name = semantic_interface_name
         if semantic_interface_name in self.names:
             raise DuplicateNameException(
                 semantic_interface_name, package_name,
@@ -351,6 +353,7 @@ class SpecIndex(object):
             this capability provider implements is not found.
         """
         provider_name = '{package}/{name}'.format(package=package_name, name=provider.name)
+        provider.name = provider_name
         if provider_name in self.names:
             raise DuplicateNameException(
                 provider_name, package_name,

--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -235,7 +235,7 @@ class CapabilityServer(object):
         self.__start_capability_service = rospy.Service(
             'start_capability', StartCapability, self.handle_start_capability)
 
-        self.__start_capability_service = rospy.Service(
+        self.__stop_capability_service = rospy.Service(
             'stop_capability', StopCapability, self.handle_stop_capability)
 
         self.__reload_service = rospy.Service(
@@ -408,8 +408,8 @@ class CapabilityServer(object):
         return instances
 
     def __get_providers_for_interface(self, interface):
-        providers = dict([(p.name, p)
-                          for p in self.__spec_index.providers.values()
+        providers = dict([(n, p)
+                          for n, p in self.__spec_index.providers.items()
                           if p.implements == interface])
         if not providers:
             raise RuntimeError("No providers for Capability '{0}'"
@@ -487,8 +487,8 @@ class CapabilityServer(object):
 
     def handle_get_providers(self, req):
         if req.interface:
-            providers = [p.name
-                         for p in self.__spec_index.providers.values()
+            providers = [n
+                         for n, p in self.__spec_index.providers.items()
                          if p.implements == req.interface]
         else:
             providers = self.__spec_index.provider_names


### PR DESCRIPTION
Following the tutorial I got stuck with start the capability.

```
$ rosservice call /get_interfaces "{}" 
interfaces: ['minimal_pkg/Minimal']
$ rosservice call /get_providers "{}" 
providers: ['minimal_pkg/minimal', 'minimal_pkg/specific_minimal']
$ rosservice call /start_capability minimal_pkg/Minimal minimal_pkg/minimal
ERROR: service [/start_capability] responded with an error: error processing request: Capability Provider 'minimal_pkg/minimal' not found for Capability 'minimal_pkg/Minimal'
```
