### PR TITLE
Avoid tracebacks for "expected" errors?

### DIFF
--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -1,7 +1,9 @@
 <launch>
     <arg name="test_case" default="minimal" />
+    <arg name="debug" default="false" />
 
     <node pkg="capabilities" name="capability_server" type="capability_server" output="screen">
         <env name="ROS_PACKAGE_PATH" value="$(find capabilities)/test/discovery_workspaces/$(arg test_case):$(env ROS_PACKAGE_PATH)" />
+        <param name="debug" value="true" if="$(arg debug)"/>
     </node>
 </launch>


### PR DESCRIPTION
For cases like a stop request for a not running capability or a start request for unknown capabilities/provides, once currently gets a ros error plus a traceback. Can this traceback be avoided? It adds a lot of output, where as the ros error gives enough information already.

```
[INFO] [WallTime: 1378857082.898716] Request to stop capability 'minimal_pkg/Minimal'
Traceback (most recent call last):
  File "/opt/ros/hydro/lib/python2.7/dist-packages/rospy/impl/tcpros_service.py", line 619, in _handle_request
    response = convert_return_to_response(self.handler(request), self.response_class)
  File "/opt/kobuki_workspace/catkin_ws/src/capabilities/src/capabilities/server.py", line 477, in handle_stop_capability
    self.__stop_capability(capability)
  File "/opt/kobuki_workspace/catkin_ws/src/capabilities/src/capabilities/server.py", line 383, in __stop_capability
    self.__launch_manager.stop_capability_provider(capability.pid)
  File "/opt/kobuki_workspace/catkin_ws/src/capabilities/src/capabilities/launch_manager.py", line 120, in stop_capability_provider
    self.__stop_by_pid(pid)
  File "/opt/kobuki_workspace/catkin_ws/src/capabilities/src/capabilities/launch_manager.py", line 107, in __stop_by_pid
    raise RuntimeError("No running launch file with PID of '{0}'".format(pid))
RuntimeError: No running launch file with PID of '5651'
[ERROR] [WallTime: 1378857082.899984] Error processing request: No running launch file with PID of '5651
```
