### PR TITLE
Support for system default providers

### DIFF
--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -2,8 +2,11 @@
     <arg name="test_case" default="minimal" />
     <arg name="debug" default="false" />
 
-    <node pkg="capabilities" name="capability_server" type="capability_server" output="screen">
-        <env name="ROS_PACKAGE_PATH" value="$(find capabilities)/test/discovery_workspaces/$(arg test_case):$(env ROS_PACKAGE_PATH)" />
-        <param name="debug" value="true" if="$(arg debug)"/>
+    <node pkg="capabilities" name="capability_server" type="capability_server" output="screen" required="true">
+        <env name="ROS_PACKAGE_PATH"
+             value="$(find capabilities)/test/discovery_workspaces/$(arg test_case):$(env ROS_PACKAGE_PATH)" />
+        <param name="debug" value="true" if="$(arg debug)" />
+        <!-- Uncomment below to explicitly set the default provider for minimal_pkg/Minimal -->
+        <!-- <param name="defaults/minimal_pkg/Minimal" value="minimal_pkg/minimal" /> -->
     </node>
 </launch>

--- a/msg/CapabilitySpec.msg
+++ b/msg/CapabilitySpec.msg
@@ -1,3 +1,15 @@
+# Package which contains this spec file
 string package
+
+# Type of spec file, one of:
+#   'capability_interface'
+#   'semantic_capability_interface'
+#   'capability_provider'
 string type
+
+# Raw string content of the spec file
 string content
+
+# The name of the default provider (pulled from ROS param's)
+# (only used for capability_interface specs)
+string default_provider

--- a/src/capabilities/service_discovery.py
+++ b/src/capabilities/service_discovery.py
@@ -72,11 +72,16 @@ def spec_index_from_service(server_node_name='capability_server'):
             'semantic_capability_interface': [],
             'capability_provider': []
         })
-        package_dict[spec.type].append(spec.content)
+        if spec.type == 'capability_interface':
+            package_dict[spec.type].append((spec.content, spec.default_provider))
+        else:
+            package_dict[spec.type].append(spec.content)
         spec_raw_index[spec.package] = package_dict
 
-    def capability_interface_loader(raw, package_name, spec_index):
+    def capability_interface_loader(interface_tuple, package_name, spec_index):
+        raw, default_provider = interface_tuple
         interface = capability_interface_from_string(raw)
+        interface.default_provider = default_provider
         spec_index.add_interface(interface, 'service call', package_name)
 
     def semantic_capability_loader(raw, package_name, spec_index):

--- a/src/capabilities/specs/interface.py
+++ b/src/capabilities/specs/interface.py
@@ -464,6 +464,7 @@ class CapabilityInterface(Interface):
     - spec_type (str): type of the interface specification (has to be 'interface')
     - spec_version (int): version of the interface specification
     - description (str): free form description of the interface
+    - default_provider (str): name of the default provider for this interface, defaults to 'unknown'
     - interface (:py:class:`Interface`): representation of components which make up the interface
     """
     spec_type = 'interface'
@@ -472,4 +473,5 @@ class CapabilityInterface(Interface):
         self.name = name
         self.spec_version = spec_version
         self.description = description
+        self.default_provider = 'unknown'
         Interface.__init__(self)


### PR DESCRIPTION
One feature that would be very helpful for deploying this on robots, and making it easier on applications developers to hop from robot to robot, is the notion of a set of system/platform defaults, so that a robot manufacturer may easily set the default set of capabilities that should be preferred when not overwritten by a particular preference passed by an app.

For instance, almost every robot will implement the _Navigation_ capability, but will do so in their own package/launch file, setting important parameters and configurations for that robot. As an application developer, your application should be able to run on any of these robots, and simply ask for "Navigation" and get the proper config for the robot.

I'm not sure how we want to implement these -- should they be parameters to the capabilities server? That way, when the main robot launch file that brings up drivers/roscore is launched, you've set the defaults.
