### PR TITLE
Reduce error to warning

### DIFF
--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -319,7 +319,7 @@ class CapabilityServer(object):
                 self.__default_providers[interface] = rospy.get_param('~defaults/' + interface)
             except KeyError:
                 # No ros parameter set for this capability interface
-                rospy.logerr("No default provider given for capability interface '{0}'. ".format(interface))
+                rospy.logwarn("No default provider given for capability interface '{0}'. ".format(interface))
                 if len(providers) == 1:
                     # If there is only one provider, allow it to be the default
                     rospy.logwarn("'{0}' has only one provider, '{1}', using that as the default."


### PR DESCRIPTION
With these messages, I should reduce the error to a warning:

```
[ERROR] [WallTime: 1379029882.343308] No default provider given for capability interface 'minimal_pkg/Minimal'. 
[WARN] [WallTime: 1379029882.343547] 'minimal_pkg/Minimal' has only one provider, 'minimal_pkg/minimal', using that as the default.
```
