### PR TITLE
Allow request for specific capabilty specification in GetCapabilitySpecs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,11 +13,12 @@ add_message_files(FILES
 )
 
 add_service_files(FILES
+    GetCapabilitySpec.srv
     GetCapabilitySpecs.srv
     GetInterfaces.srv
     GetProviders.srv
-    GetSemanticInterfaces.srv
     GetRunningCapabilities.srv
+    GetSemanticInterfaces.srv
     StartCapability.srv
     StopCapability.srv
 )

--- a/srv/GetCapabilitySpec.srv
+++ b/srv/GetCapabilitySpec.srv
@@ -1,0 +1,3 @@
+string capability_spec
+---
+CapabilitySpec capability_spec

--- a/test/rostest/test_server/test_ros_services.py
+++ b/test/rostest/test_server/test_ros_services.py
@@ -85,6 +85,11 @@ class Test(unittest.TestCase):
         si, errors = spec_index_from_service()
         assert not errors
         assert 'minimal_pkg/Minimal' in si.interfaces
+        resp = call_service('/capability_server/get_capability_spec', 'minimal_pkg/Minimal')
+        assert resp.capability_spec.package == 'minimal_pkg', resp.capability_spec.package
+        assert 'name: Minimal' in resp.capability_spec.content, resp.capability_spec.content
+        with assert_raises(ServiceException):
+            resp = call_service('/capability_server/get_capability_spec', 'minimal_pkg/DoesNotExist')
 
     def test_external_event(self):
         # publish even from external rospy instance


### PR DESCRIPTION
Currently the response of this service call contains all capability specs, which probably will be a lot in the near future. Hence, I'd like to have the option to request a specific capability specification.
