### PR TITLE
Pass roslaunch's --screen option down to launched capabilities

### DIFF
--- a/src/capabilities/launch_manager.py
+++ b/src/capabilities/launch_manager.py
@@ -83,7 +83,7 @@ class LaunchManager(object):
     __roslaunch_exec = which('roslaunch')
     __python_exec = which('python')
 
-    def __init__(self, quiet=False):
+    def __init__(self, quiet=False, screen=False):
         self.__running_launch_files_lock = threading.Lock()
         with self.__running_launch_files_lock:
             self.__running_launch_files = {}
@@ -93,6 +93,7 @@ class LaunchManager(object):
             "~events", CapabilityEvent, self.handle_capability_events)
         self.stopping = False
         self.__quiet = quiet
+        self.__screen = screen
 
     def stop(self):
         """Stops the launch manager, also stopping any running launch files"""
@@ -161,7 +162,10 @@ class LaunchManager(object):
             if launch_file is None:
                 cmd = [self.__python_exec, _placeholder_script]
             else:
-                cmd = [self.__roslaunch_exec, launch_file]
+                if self.__screen:
+                    cmd = [self.__roslaunch_exec, '--screen', launch_file]
+                else:
+                    cmd = [self.__roslaunch_exec, launch_file]
             if self.__quiet:
                 env = copy.deepcopy(os.environ)
                 env['PYTHONUNBUFFERED'] = 'x'

--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -227,12 +227,12 @@ class CapabilityServer(object):
     """A class to expose the :py:class:`discovery.SpecIndex` over a ROS API
     """
 
-    def __init__(self, package_paths):
+    def __init__(self, package_paths, screen=None):
         self.__package_paths = package_paths
         self.__spec_index = None
         self.__graph_lock = threading.Lock()
         self.__capability_instances = {}
-        self.__launch_manager = LaunchManager()
+        self.__launch_manager = LaunchManager(screen=bool(rospy.get_param('~use_screen', screen)))
         self.__debug = False
         self.__default_providers = {}
 
@@ -676,6 +676,8 @@ def create_parser():
     add = parser.add_argument
     add('package_path', nargs='?',
         help="Overrides ROS_PACKAGE_PATH when discovering capabilities")
+    add('--screen', '-s', action='store_true', default=False,
+        help="Passes `--screen` down to roslaunch, `use_screen` rosparam takes priority.")
     return parser
 
 
@@ -696,6 +698,6 @@ def main(sysargv=None):
 
     rospy.init_node('capability_server')
 
-    capability_server = CapabilityServer(ros_package_path)
+    capability_server = CapabilityServer(ros_package_path, screen=args.screen)
     capability_server.spin()
     capability_server.shutdown()

--- a/test/rostest/test_launch_manager/test_launch_manager.py
+++ b/test/rostest/test_launch_manager/test_launch_manager.py
@@ -45,6 +45,21 @@ class Test(unittest.TestCase):
             time.sleep(1)  # Allow time for output to be produced
             lm.stop()
 
+    def test_launch_manager_screen(self):
+        with redirected_stdio():
+            workspaces = [os.path.join(TEST_DIR, 'unit', 'discovery_workspaces', 'minimal')]
+            package_index = package_index_from_package_path(workspaces)
+            spec_file_index = spec_file_index_from_package_index(package_index)
+            spec_index, errors = spec_index_from_spec_file_index(spec_file_index)
+            assert not errors, errors
+            provider = 'minimal_pkg/minimal'
+            assert provider in spec_index.providers
+            lm = launch_manager.LaunchManager()
+            lm._LaunchManager__screen = True
+            lm.run_capability_provider(spec_index.providers[provider], spec_index.provider_paths[provider])
+            time.sleep(1)  # Allow time for output to be produced
+            lm.stop()
+
     def test_launch_manager_no_launch_file_provider(self):
         with redirected_stdio():
             workspaces = [os.path.join(THIS_DIR, 'no_launch_file')]


### PR DESCRIPTION
Although I started the capability server with `--screen`, the output of the started apps is not pipe to the terminal.
