### PR TITLE
Prun caps without default provider

### DIFF
--- a/test/rostest/test_server/test_invalid_specs.py
+++ b/test/rostest/test_server/test_invalid_specs.py
@@ -6,6 +6,7 @@ import os
 import sys
 import unittest
 
+import rospy
 import rostest
 
 from capabilities import server
@@ -28,13 +29,22 @@ class Test(unittest.TestCase):
         capability_server._CapabilityServer__populate_default_providers()
         capability_server._CapabilityServer__stop_capability('not_a_running_capability')
 
-    def test_no_default_provider(self):
+    def test_no_default_provider_pedantic(self):
         no_default_provider = os.path.join(TEST_DIR, 'rostest', 'test_server', 'no_default_provider')
         ros_package_path = [no_default_provider]
+        rospy.set_param('~missing_default_provider_is_an_error', True)
         capability_server = server.CapabilityServer(ros_package_path)
         capability_server._CapabilityServer__load_capabilities()
         with assert_raises(SystemExit):
             capability_server._CapabilityServer__populate_default_providers()
+
+    def test_no_default_provider(self):
+        no_default_provider = os.path.join(TEST_DIR, 'rostest', 'test_server', 'no_default_provider')
+        ros_package_path = [no_default_provider]
+        rospy.set_param('~missing_default_provider_is_an_error', False)
+        capability_server = server.CapabilityServer(ros_package_path)
+        capability_server._CapabilityServer__load_capabilities()
+        capability_server._CapabilityServer__populate_default_providers()
 
     def test_invalid_default_provider(self):
         minimal_dir = os.path.join(TEST_DIR, 'unit', 'discovery_workspaces', 'minimal')


### PR DESCRIPTION
Currently the capability server aborts, if multiple providers for an interface are available, but no default is set.

While this behaviour is all right when only few capabilities are available, it starts to annoy, when lots of capabilities with providers are discovered. In that case one has to set a default provider for each interface even though it is not used.

Suggestion:
Instead of aborting the start of the capability server, we just prune the capability from the available list and through a warning.

On the flip side implementing this suggestion might lead to a noise capability server in the future, when the ROS community starts to produce various interfaces. At that point most of use would need to live with always getting lots of warnings.

This makes me think, if we should change the way capabilities are discovered. I like the current approach with exporting the capabilities in the package.xml a lot, since it is so convenient. However, looking at the above issue we might need to modify or completely change it. E.g. the app manager only parses given app lists.
