### PR TITLE
Allow provider specs to contain remapping rules

### DIFF
--- a/test/unit/specs/providers/invalid_depends_on_conditional.yaml
+++ b/test/unit/specs/providers/invalid_depends_on_conditional.yaml
@@ -5,7 +5,8 @@ spec_version: 1
 spec_type: provider
 implements: a_package/Something
 depends_on:
-    'SomethingElse':
-        remappings_typo:
-            dynamic_parameter:
-                'foo': 'bar'
+    'some_pkg/SomethingElse':
+        provider_typo: 'some_pkg/SomeProvider'
+remappings_typo:
+    dynamic_parameter:
+        'foo': 'bar'

--- a/test/unit/specs/providers/invalid_depends_on_section.yaml
+++ b/test/unit/specs/providers/invalid_depends_on_section.yaml
@@ -4,5 +4,4 @@ name: invalid_remapping
 spec_version: 1
 spec_type: provider
 implements: a_package/Something
-depends_on:
-    - foo
+depends_on: null

--- a/test/unit/specs/providers/invalid_remapping.yaml
+++ b/test/unit/specs/providers/invalid_remapping.yaml
@@ -4,8 +4,5 @@ name: invalid_remapping
 spec_version: 1
 spec_type: provider
 implements: a_package/Something
-depends_on:
-    'a_package/SomethingElse':
-        remappings:
-            dynamic_parameter:
-                'foo': 'bar'
+depends_on: 'a_package/SomethingElse'
+remappings: 'not_a_dict'

--- a/test/unit/specs/providers/invalid_remapping_duplicate.yaml
+++ b/test/unit/specs/providers/invalid_remapping_duplicate.yaml
@@ -4,10 +4,9 @@ name: invalid_remapping_duplicate
 spec_version: 1
 spec_type: provider
 implements: a_package/Something
-depends_on:
-    'a_package/SomethingElse':
-        remappings:
-            topics:
-                'foo': 'bar'
-            services:
-                'foo': 'baz'
+depends_on: 'a_package/SomethingElse'
+remappings:
+    topics:
+        'foo': 'bar'
+    services:
+        'foo': 'baz'

--- a/test/unit/specs/providers/minimal.yaml
+++ b/test/unit/specs/providers/minimal.yaml
@@ -4,3 +4,4 @@ name: minimal
 spec_version: 1
 spec_type: provider
 implements: minimal_pkg/Minimal
+depends_on: 'some_pkg/SomeThing'

--- a/test/unit/specs/providers/navigation_nav_stack.yaml
+++ b/test/unit/specs/providers/navigation_nav_stack.yaml
@@ -8,7 +8,7 @@ implements: navigation/Navigation
 launch_file: 'launch/navigation_nav_stack.launch'
 depends_on:
     'laser_capability/LaserObservation':
-        remappings:
-            topics:
-                'scan': 'nav_stack/scan'
         provider: 'hokuyo_capability/hokuyo_base'
+remappings:
+    topics:
+        'scan': 'nav_stack/scan'

--- a/test/unit/specs/test_provider.py
+++ b/test/unit/specs/test_provider.py
@@ -20,8 +20,8 @@ def check_navigation(cp):
     assert cp.launch_file == 'launch/navigation_nav_stack.launch'
     assert cp.depends_on('laser_capability/LaserObservation'), cp.dependencies
     str(cp.dependencies['laser_capability/LaserObservation'])
-    assert 'scan' in cp.dependencies['laser_capability/LaserObservation'].remappings
-    assert 'nav_stack/scan' == cp.dependencies['laser_capability/LaserObservation'].remappings['scan']
+    assert 'scan' in cp.remappings
+    assert 'nav_stack/scan' == cp.remappings['scan']
     assert 'hokuyo_capability/hokuyo_base' == cp.dependencies['laser_capability/LaserObservation'].provider
     with assert_raises_regex(AttributeError, "can't set attribute"):
         cp.dependencies = {'SomeInterface': {}}
@@ -41,7 +41,7 @@ test_files_map = {
     'invalid_depends_on_conditional_section.yaml': [None, provider.InvalidProvider, 'depends_on conditional section'],
     'invalid_depends_on_section.yaml': [None, provider.InvalidProvider, 'Invalid depends_on section'],
     'invalid_remapping_duplicate.yaml': [None, provider.InvalidProvider, 'is remapped twice, but to different values'],
-    'invalid_remapping.yaml': [None, provider.InvalidProvider, 'Invalid remapping type'],
+    'invalid_remapping.yaml': [None, provider.InvalidProvider, 'Invalid remappings section'],
     'invalid_spec_type.yaml': [None, provider.InvalidProvider, 'Invalid spec type'],
     'minimal.yaml': [check_minimal, None, None],
     'navigation_nav_stack.yaml': [check_navigation, None, None],


### PR DESCRIPTION
This was proposed as a solution to the providers which need to rename things in order to satisfy semantic interface names.

See: #22
