### PR TITLE
Support for nodelet managers

### DIFF
--- a/test/unit/specs/providers/invalid_nodelet_manager.yaml
+++ b/test/unit/specs/providers/invalid_nodelet_manager.yaml
@@ -1,0 +1,7 @@
+%YAML 1.1
+---
+name: minimal
+spec_version: 1
+spec_type: provider
+implements: minimal_pkg/Minimal
+nodelet_manager: {'not': 'valid'}

--- a/test/unit/specs/providers/navigation_nav_stack.yaml
+++ b/test/unit/specs/providers/navigation_nav_stack.yaml
@@ -6,6 +6,7 @@ spec_type: provider
 description: 'Implements the ability to navigate.'
 implements: navigation/Navigation
 launch_file: 'launch/navigation_nav_stack.launch'
+nodelet_manager: 'nav_manager'
 depends_on:
     'laser_capability/LaserObservation':
         provider: 'hokuyo_capability/hokuyo_base'

--- a/test/unit/specs/test_provider.py
+++ b/test/unit/specs/test_provider.py
@@ -40,17 +40,18 @@ test_files_map = {
     'invalid_depends_on_conditional.yaml': [None, provider.InvalidProvider, 'Invalid depends_on interface condition'],
     'invalid_depends_on_conditional_section.yaml': [None, provider.InvalidProvider, 'depends_on conditional section'],
     'invalid_depends_on_section.yaml': [None, provider.InvalidProvider, 'Invalid depends_on section'],
-    'invalid_remapping_duplicate.yaml': [None, provider.InvalidProvider, 'is remapped twice, but to different values'],
+    'invalid_implements_name.yaml': [None, provider.InvalidProvider, 'Invalid spec name for implements'],
+    'invalid_nodelet_manager.yaml': [None, provider.InvalidProvider, 'Invalid nodelet_manager'],
     'invalid_remapping.yaml': [None, provider.InvalidProvider, 'Invalid remappings section'],
+    'invalid_remapping_duplicate.yaml': [None, provider.InvalidProvider, 'is remapped twice, but to different values'],
     'invalid_spec_type.yaml': [None, provider.InvalidProvider, 'Invalid spec type'],
     'minimal.yaml': [check_minimal, None, None],
     'navigation_nav_stack.yaml': [check_navigation, None, None],
     'no_implements.yaml': [None, provider.InvalidProvider, 'No implements specified'],
     'no_name.yaml': [None, provider.InvalidProvider, 'No name specified'],
-    'no_spec_version.yaml': [None, provider.InvalidProvider, 'No spec version specified'],
     'no_spec_type.yaml': [None, provider.InvalidProvider, 'No spec type specified'],
+    'no_spec_version.yaml': [None, provider.InvalidProvider, 'No spec version specified'],
     'version_2_spec.yaml': [None, provider.InvalidProvider, 'Invalid spec version'],
-    'invalid_implements_name.yaml': [None, provider.InvalidProvider, 'Invalid spec name for implements'],
 }
 
 


### PR DESCRIPTION
Kobuki's driver and controllers being implemented using nodelets quickly causes headaches, when starting to use namespaces. For now, we could only solve this by using absolute names for the nodelet's managers. Hence, you can't change the nodelet manager's namespace.

We need to find a way to handle this via capabilities. But how?

A first suggestion, support a `nodelet_manager_name` parameter in the interfaces.

Better ideas?
