### PR TITLE
add timeout to service_discovery.spec_index_from_service

### DIFF
--- a/src/capabilities/service_discovery.py
+++ b/src/capabilities/service_discovery.py
@@ -49,7 +49,7 @@ from capabilities.specs.semantic_interface import semantic_capability_interface_
 from capabilities.discovery import _spec_loader
 
 
-def spec_index_from_service(server_node_name='capability_server'):
+def spec_index_from_service(server_node_name='capability_server', timeout=None):
     """Builds a :py:class:`SpecIndex` by calling a ROS service to get the specs
 
     Works just like :py:func:`spec_index_from_spec_file_index`, except the raw
@@ -58,11 +58,13 @@ def spec_index_from_service(server_node_name='capability_server'):
     :param server_node_name: Name of the capability server's node,
         default is 'capability_server'
     :type server_node_name: str
+    :param timeout: timeout for waiting on service to be available
+    :type timeout: float
 
     :raises: :py:class:`rospy.ServiceException` when the service call fails
     """
     service_name = '/{0}/get_capability_specs'.format(server_node_name)
-    rospy.wait_for_service(service_name)
+    rospy.wait_for_service(service_name, timeout)
     get_capability_specs = rospy.ServiceProxy(service_name, GetCapabilitySpecs)
     response = get_capability_specs()
     spec_raw_index = {}


### PR DESCRIPTION
I'm using this in the app manager and are currently forced to add an extra timeout (wait_for_service).

Would be nicer (and cleaner?), if this would be handled by service_discovery.
