### PR TITLE
remove use of hacks

### DIFF
--- a/scripts/capability_server
+++ b/scripts/capability_server
@@ -2,25 +2,6 @@
 
 import sys
 
-#### HACK until rospy uses the threading module rather than the thread module
-import threading
-
-from rospy.impl import tcpros_service
-
-
-class MyThread(object):
-    def __init__(self):
-        self.__threads_objs = []
-
-    def start_new_thread(self, func, args):
-        t = threading.Thread(target=func, args=args)
-        t.setDaemon(True)
-        t.start()
-        self.__threads_objs.append(t)
-
-tcpros_service._thread = MyThread()
-#### END HACK
-
 from capabilities.server import main
 
 if __name__ == '__main__':


### PR DESCRIPTION
This hack:

https://github.com/osrf/capabilities/blob/master/scripts/capability_server#L5-L22

Can be removed since `rospy` version `1.9.50` is now out:

http://www.ros.org/debbuild/hydro.html?q=rospy
http://www.ros.org/debbuild/groovy.html?q=rospy

We should also investigate making an upstream fix/change for this hack:

https://github.com/osrf/capabilities/blob/master/src/capabilities/server.py#L91-L116
