### PR TITLE
Unknown capability instance: ''

### DIFF
--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -470,6 +470,9 @@ class CapabilityServer(object):
         # Ignore any publications which we did not send (external publishers)
         if event._connection_header['callerid'] != rospy.get_name():
             return  # pragma: no cover
+        # Ignore the `server_ready` event
+        if event.type == event.SERVER_READY:
+            return
         # Update the capability
         capability = event.capability
         with self.__graph_lock:


### PR DESCRIPTION
This error message gets printed every time I run the capability server. I've seen this in a catkin workspace with several interfaces and providers, and I'm able to reproduce it on a workspace with no capabilities or providers:

```
jbinney@h-> rosrun capabilities capability_server 
[WARN] [WallTime: 1391825562.852679] [0.000000] No runnable Capabilities loaded.
[INFO] [WallTime: 1391825562.868363] [0.000000] Capability Server Ready
[ERROR] [WallTime: 1391825562.869098] [0.000000] Unknown capability instance: ''
```

It looks like on startup the following event message comes out on `/capability_server/events`:

```
header: 
  seq: 1
  stamp: 
    secs: 0
    nsecs: 0
  frame_id: ''
capability: ''
provider: ''
type: "server_ready"
pid: 0
```

And the capability field being an empty string confuses the event handler: https://github.com/osrf/capabilities/blob/master/src/capabilities/server.py#L476
