### PR TITLE
added a builtin nodelet manager to the server

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ install:
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get install ros-hydro-roslaunch ros-hydro-rospy ros-hydro-std-msgs ros-hydro-std-srvs ros-hydro-geometry-msgs ros-hydro-message-generation ros-hydro-message-runtime ros-hydro-catkin ros-hydro-rostest ros-hydro-rosservice
+  - sudo apt-get install ros-hydro-nodelet ros-hydro-roslaunch ros-hydro-rospy ros-hydro-std-msgs ros-hydro-std-srvs ros-hydro-geometry-msgs ros-hydro-message-generation ros-hydro-message-runtime ros-hydro-catkin ros-hydro-rostest ros-hydro-rosservice
+# Install image_proc to get a nodelet instaleld as a workaround to https://github.com/ros/pluginlib/pull/22
+  - sudo apt-get install ros-hydro-image-proc
 # command to run tests
 script:
   - source /opt/ros/hydro/setup.bash

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ coverage:
 	-rm ~/.ros/.coverage
 	-rm ${BUILD_DIR}/.coverage
 	-rm ./.coverage
-	cd ${BUILD_DIR} && mkdir src
-	ln -s ${SRC_DIR} ${BUILD_DIR}/src
+	-ln -s ${SRC_DIR} ${BUILD_DIR}/src
 	cd ${BUILD_DIR} && catkin_make
 	cd ${BUILD_DIR} && catkin_make tests
 	cd ${BUILD_DIR} && catkin_make -j1 run_tests

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <build_depend>std_srvs</build_depend>
 
   <run_depend>message_runtime</run_depend>
+  <run_depend>nodelet</run_depend>
   <run_depend>python-yaml</run_depend>
   <run_depend>roslaunch</run_depend>
   <run_depend>rospy</run_depend>

--- a/src/capabilities/capability_server_nodelet_manager.launch
+++ b/src/capabilities/capability_server_nodelet_manager.launch
@@ -1,0 +1,6 @@
+<launch>
+    <arg name="capability_server_nodelet_manager_name" default="capability_server_nodelet_manager" />
+    <node pkg="nodelet" type="nodelet"
+          name="$(arg capability_server_nodelet_manager_name)"
+          output="screen" args="manager" />
+</launch>

--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -76,6 +76,7 @@ from capabilities.discovery import package_index_from_package_path
 from capabilities.discovery import spec_file_index_from_package_index
 from capabilities.discovery import spec_index_from_spec_file_index
 
+from capabilities.launch_manager import _special_nodelet_manager_capability
 from capabilities.launch_manager import LaunchManager
 
 from capabilities.msg import Capability
@@ -473,6 +474,14 @@ class CapabilityServer(object):
         # Ignore the `server_ready` event
         if event.type == event.SERVER_READY:
             return
+        # Specially handle the nodelet manager
+        if event.capability == _special_nodelet_manager_capability:
+            if event.type == event.LAUNCHED:
+                return
+            elif event.type == event.TERMINATED:
+                if not rospy.is_shutdown():
+                    rospy.logerr("Capability server's nodelet manager terminated unexpectedly.")
+                    self.shutdown()
         # Update the capability
         capability = event.capability
         with self.__graph_lock:

--- a/test/rostest/test_launch_manager/test_launch_manager.py
+++ b/test/rostest/test_launch_manager/test_launch_manager.py
@@ -77,10 +77,13 @@ class Test(unittest.TestCase):
 
     def test_process_monitoring(self):
         lm = launch_manager.LaunchManager()
-        with assert_raises_regex(RuntimeError, 'Unknown process id'):
-            proc = Mock()
-            proc.pid = -1
-            lm._LaunchManager__monitor_process(proc)
+        try:
+            with assert_raises_regex(RuntimeError, 'Unknown process id'):
+                proc = Mock()
+                proc.pid = -1
+                lm._LaunchManager__monitor_process(proc)
+        finally:
+            lm.stop()
 
 if __name__ == '__main__':
     import rospy

--- a/test/rostest/test_server/test_invalid_specs.py
+++ b/test/rostest/test_server/test_invalid_specs.py
@@ -28,6 +28,7 @@ class Test(unittest.TestCase):
         capability_server._CapabilityServer__load_capabilities()
         capability_server._CapabilityServer__populate_default_providers()
         capability_server._CapabilityServer__stop_capability('not_a_running_capability')
+        capability_server.shutdown()
 
     def test_no_default_provider_pedantic(self):
         no_default_provider = os.path.join(TEST_DIR, 'rostest', 'test_server', 'no_default_provider')
@@ -37,6 +38,7 @@ class Test(unittest.TestCase):
         capability_server._CapabilityServer__load_capabilities()
         with assert_raises(SystemExit):
             capability_server._CapabilityServer__populate_default_providers()
+        capability_server.shutdown()
 
     def test_no_default_provider(self):
         no_default_provider = os.path.join(TEST_DIR, 'rostest', 'test_server', 'no_default_provider')
@@ -45,6 +47,7 @@ class Test(unittest.TestCase):
         capability_server = server.CapabilityServer(ros_package_path)
         capability_server._CapabilityServer__load_capabilities()
         capability_server._CapabilityServer__populate_default_providers()
+        capability_server.shutdown()
 
     def test_invalid_default_provider(self):
         minimal_dir = os.path.join(TEST_DIR, 'unit', 'discovery_workspaces', 'minimal')
@@ -54,6 +57,7 @@ class Test(unittest.TestCase):
         capability_server._CapabilityServer__load_capabilities()
         with assert_raises(SystemExit):
             capability_server._CapabilityServer__populate_default_providers()
+        capability_server.shutdown()
 
     def test_wrong_default_provider(self):
         dc_dir = os.path.join(TEST_DIR, 'unit', 'discovery_workspaces', 'dependent_capabilities')
@@ -64,6 +68,7 @@ class Test(unittest.TestCase):
         capability_server._CapabilityServer__load_capabilities()
         with assert_raises(SystemExit):
             capability_server._CapabilityServer__populate_default_providers()
+        capability_server.shutdown()
 
     def test_event_handler(self):
         invalid_specs_dir = os.path.join(TEST_DIR, 'unit', 'discovery_workspaces', 'invalid_specs')
@@ -80,6 +85,7 @@ class Test(unittest.TestCase):
         msg.type = 'doesnt matter'
         pub.publish(msg)
         rospy.sleep(1)  # Allow time for the publish to happen
+        capability_server.shutdown()
 
 if __name__ == '__main__':
     rospy.init_node(TEST_NAME, anonymous=True)


### PR DESCRIPTION
All launch files now get the argument `capability_server_nodelet_manager_name` set to the name of the nodelet manager so that they may use it to load their nodelet's into.

Closes #42
