### PR TITLE
added a service to get the nodelet manager's name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_service_files(FILES
     GetCapabilitySpec.srv
     GetCapabilitySpecs.srv
     GetInterfaces.srv
+    GetNodeletManagerName.srv
     GetProviders.srv
     GetRunningCapabilities.srv
     GetSemanticInterfaces.srv

--- a/src/capabilities/launch_manager.py
+++ b/src/capabilities/launch_manager.py
@@ -100,6 +100,10 @@ class LaunchManager(object):
         self.__nodelet_manager_name = nodelet_manager_name or (rospy.get_name().lstrip('/') + '_nodelet_manager')
         self.__start_nodelet_manager()
 
+    @property
+    def nodelet_manager_name(self):
+        return self.__nodelet_manager_name
+
     def stop(self):
         """Stops the launch manager, also stopping any running launch files"""
         if self.stopping:

--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -61,6 +61,8 @@ from capabilities.srv import GetCapabilitySpecs
 from capabilities.srv import GetCapabilitySpecsResponse
 from capabilities.srv import GetInterfaces
 from capabilities.srv import GetInterfacesResponse
+from capabilities.srv import GetNodeletManagerName
+from capabilities.srv import GetNodeletManagerNameResponse
 from capabilities.srv import GetProviders
 from capabilities.srv import GetProvidersResponse
 from capabilities.srv import GetSemanticInterfaces
@@ -332,6 +334,10 @@ class CapabilityServer(object):
         self.__capability_spec = rospy.Service(
             '~get_capability_spec', GetCapabilitySpec,
             self.handle_get_capability_spec)
+
+        self.__get_nodelet_manager_name_service = rospy.Service(
+            '~get_nodelet_manager_name', GetNodeletManagerName,
+            self.handle_get_nodelet_manager_name)
 
         rospy.Subscriber(
             '~events', CapabilityEvent, self.handle_capability_events)
@@ -763,6 +769,14 @@ class CapabilityServer(object):
             for dep in rdepends:
                 running_capability.dependent_capabilities.append(Capability(dep.interface, dep.name))
             resp.running_capabilities.append(running_capability)
+        return resp
+
+    def handle_get_nodelet_manager_name(self, req):
+        return self.__catch_and_log(self._handle_get_nodelet_manager_name, req)
+
+    def _handle_get_nodelet_manager_name(self, req):
+        resp = GetNodeletManagerNameResponse()
+        resp.nodelet_manager_name = self.__launch_manager.nodelet_manager_name
         return resp
 
 

--- a/srv/GetNodeletManagerName.srv
+++ b/srv/GetNodeletManagerName.srv
@@ -1,0 +1,3 @@
+
+---
+string nodelet_manager_name

--- a/test/rostest/test_server/test_ros_services.py
+++ b/test/rostest/test_server/test_ros_services.py
@@ -64,6 +64,9 @@ class Test(unittest.TestCase):
         # get semantic interfaces by interface
         resp = call_service('/capability_server/get_semantic_interfaces', 'minimal_pkg/Minimal')
         assert 'minimal_pkg/SpecificMinimal' in resp.semantic_interfaces, resp
+        # get nodelet manager name
+        resp = call_service('/capability_server/get_nodelet_manager_name')
+        assert resp.nodelet_manager_name == 'capability_server_nodelet_manager', resp
 
     def test_start_stop_capabilities(self):
         # fail to start interface without a provider


### PR DESCRIPTION
This addresses the reason for reopening #42.

closes #42
