### PR TITLE
extend capabilities/GetProviders to provide the default provider

### DIFF
--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -734,12 +734,16 @@ class CapabilityServer(object):
 
     def _handle_get_providers(self, req):
         if req.interface:
+            if req.interface not in self.__spec_index.interfaces.keys() + self.__spec_index.semantic_interfaces.keys():
+                raise RuntimeError("Capability Interface '{0}' not found.".format(req.interface))
             providers = [n
                          for n, p in self.__spec_index.providers.items()
                          if p.implements == req.interface]
+            default_provider = self.__default_providers[req.interface]
         else:
             providers = self.__spec_index.provider_names
-        return GetProvidersResponse(providers)
+            default_provider = ''
+        return GetProvidersResponse(providers, default_provider)
 
     def handle_get_semantic_interfaces(self, req):
         return self.__catch_and_log(self._handle_get_semantic_interfaces, req)

--- a/srv/GetProviders.srv
+++ b/srv/GetProviders.srv
@@ -1,3 +1,4 @@
 string interface
 ---
 string[] providers
+string default_provider

--- a/test/rostest/test_server/test_ros_services.py
+++ b/test/rostest/test_server/test_ros_services.py
@@ -55,9 +55,14 @@ class Test(unittest.TestCase):
         # get providers by interface
         resp = call_service('/capability_server/get_providers', 'minimal_pkg/Minimal')
         assert 'minimal_pkg/minimal' in resp.providers, resp
+        assert resp.default_provider == 'minimal_pkg/minimal', resp
         # get all providers
         resp = call_service('/capability_server/get_providers', '')
         assert 'minimal_pkg/minimal' in resp.providers, resp
+        assert resp.default_provider == '', resp
+        # fail to get providers for non-existent interface
+        with assert_raises(ServiceException):
+            call_service('/capability_server/get_providers', 'not_a_pkg/NotAnInterface')
         # get semantic interfaces
         resp = call_service('/capability_server/get_semantic_interfaces')
         assert 'minimal_pkg/SpecificMinimal' in resp.semantic_interfaces, resp


### PR DESCRIPTION
The app manager so far does not allow to specify a provider for an interface. Hence, always the default provider is used.

For applying the correct remappings I need to know the default provider for an interface.
My suggestion would be to add this information to the capabilities/GetProviders service.

E.g.:

```
string interface

---
string[] providers
string default_provider
```

Thoughts?
