### PR TITLE
adds support of namespaces for cap nodelets

### DIFF
--- a/src/capabilities/launch_manager.py
+++ b/src/capabilities/launch_manager.py
@@ -97,7 +97,10 @@ class LaunchManager(object):
         self.stopping = False
         self.__quiet = quiet
         self.__screen = screen
-        self.__nodelet_manager_name = nodelet_manager_name or (rospy.get_name().split('/')[-1] + '_nodelet_manager')
+        name = rospy.get_namespace()
+        name += "" if name.startswith('/') else "/"
+        name += nodelet_manager_name if nodelet_manager_name else rospy.get_name().split('/')[-1] + '_nodelet_manager'
+        self.__nodelet_manager_name = name
         self.__start_nodelet_manager()
 
     @property
@@ -169,7 +172,7 @@ class LaunchManager(object):
             launch_file = os.path.join(provider_path, provider.launch_file)
         self.run_launch_file(launch_file, provider)
 
-    def run_launch_file(self, launch_file, provider):
+    def run_launch_file(self, launch_file, provider, manager=False):
         with self.__running_launch_files_lock:
             if launch_file is not None and launch_file in [x[3] for x in self.__running_launch_files.values()]:
                 raise RuntimeError("Launch file at '{0}' is already running."
@@ -181,7 +184,10 @@ class LaunchManager(object):
                     cmd = [self.__roslaunch_exec, '--screen', launch_file]
                 else:
                     cmd = [self.__roslaunch_exec, launch_file]
-                cmd.append("capability_server_nodelet_manager_name:=" + self.__nodelet_manager_name)
+                if manager:
+                    cmd.append("capability_server_nodelet_manager_name:=" + self.__nodelet_manager_name.split('/')[-1])
+                else:
+                    cmd.append("capability_server_nodelet_manager_name:=" + self.__nodelet_manager_name)
             if self.__quiet:
                 env = copy.deepcopy(os.environ)
                 env['PYTHONUNBUFFERED'] = 'x'
@@ -207,7 +213,7 @@ class LaunchManager(object):
             name = rospy.get_name().lstrip('/')
         provider = MockProvider()
         launch_file = _nodelet_manager_launch_file
-        self.run_launch_file(launch_file, provider)
+        self.run_launch_file(launch_file, provider, manager=True)
 
     def __start_communication_thread(self, proc):
         return threading.Thread(target=self.__monitor_process, args=(proc,))

--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -912,9 +912,7 @@ class CapabilityServer(object):
 
     def _handle_get_nodelet_manager_name(self, req):
         resp = GetNodeletManagerNameResponse()
-        resp.nodelet_manager_name = rospy.get_namespace()
-        resp.nodelet_manager_name += "" if resp.nodelet_manager_name.endswith('/') else "/"
-        resp.nodelet_manager_name += self.__launch_manager.nodelet_manager_name
+        resp.nodelet_manager_name = self.__launch_manager.nodelet_manager_name
         return resp
 
     def handle_get_remappings(self, req):


### PR DESCRIPTION
The current implementation does not support cases, in which the nodelet manager and nodelets are not in the same namespace.

This PR adds this missing support and fixes #66.
