### PR TITLE
Export architecture_independent flag in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,7 @@
   <test_depend>rosservice</test_depend>
 
   <export>
+    <architecture_independent/>
     <rosdoc config="rosdoc.yaml"/>
   </export>
 


### PR DESCRIPTION
This package doesn't have any binaries in it, so it can be marked as architecture independent.

Tested on the RPM buildfarm (http://csc.mcs.sdsmt.edu/jenkins/):
- [x] No regressions
- [x] No binaries installed

See:
- https://github.com/ros/rosdistro/issues/4037
- https://github.com/ros-infrastructure/bloom/pull/270
- http://www.ros.org/reps/rep-0127.html#architecture-independent

Thanks!
