### PR TITLE
Return an error if start_capability requested for a capability that is already running

### DIFF
--- a/srv/StartCapability.srv
+++ b/srv/StartCapability.srv
@@ -1,4 +1,9 @@
 string capability
 string preferred_provider
 ---
-bool successful
+uint8 result
+uint8 RESULT_SUCCESS=0
+uint8 RESULT_CURRENTLY_STARTING=1 # Cannot start because capability is currently starting
+uint8 RESULT_CURRENTLY_RUNNING=2 # Cannot start because capability is currently running
+uint8 RESULT_CURRENTLY_STOPPING=3 # Cannot start because capability is currently stopping
+


### PR DESCRIPTION
Addresses https://github.com/osrf/capabilities/issues/78

This is a first pass; I'm open to suggestions on how to do this better. I wasn't sure how detailed of information to return to the callee; I settled on telling them whether the capability they requested is "RUNNING", "STARTING", or "STOPPING". Giving more detailed info (like "stopping" vs. "terminated") seemed like it exposed a bit too much internal state. Giving less detailed info (only that the call failed, for instance) seemed like not quite enough for many use cases.

After these changes, one of the launch_manager tests hangs - I'm having a hard time debugging it. I didn't change anything in the launch manager code, so I'm not sure what is going on.
