### PR TITLE
Prune spec files by black/white lists

### DIFF
--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -432,6 +432,13 @@ class CapabilityServer(object):
                 if provider.implements == interface:
                     spec_index.remove_provider(provider.name)
         self.__spec_index = spec_index
+        # Prune spec_file_index
+        spec_paths = spec_index.interface_paths.values() + \
+            spec_index.semantic_interface_paths.values() + \
+            spec_index.provider_paths.values()
+        for package_name, package_dict in self.spec_file_index.items():
+            for spec_type in ['capability_interface', 'semantic_capability_interface', 'capability_provider']:
+                package_dict[spec_type][:] = [path for path in package_dict[spec_type] if path in spec_paths]
 
     def __populate_default_providers(self):
         # Collect available interfaces

--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -401,7 +401,7 @@ class CapabilityServer(object):
             if self.__package_whitelist and package not in self.__package_whitelist:
                 rospy.loginfo("Package '{0}' not in whitelist, skipping.".format(package))
                 del self.spec_file_index[package]
-            if self.__package_blacklist and package in self.__package_blacklist:
+            elif self.__package_blacklist and package in self.__package_blacklist:
                 rospy.loginfo("Package '{0}' in blacklist, skipping.".format(package))
                 del self.spec_file_index[package]
         # Generate spec_index from spec file index
@@ -422,7 +422,7 @@ class CapabilityServer(object):
                     removed_interfaces.append(spec)
                     remove_func(spec)
                     rospy.loginfo("Spec '{0}' is not in the whitelist, skipping.".format(spec))
-                if self.__blacklist and spec in self.__blacklist:
+                elif self.__blacklist and spec in self.__blacklist:
                     removed_interfaces.append(spec)
                     remove_func(spec)
                     rospy.loginfo("Spec '{0}' is in the blacklist, skipping.".format(spec))

--- a/test/rostest/test_service_discovery/test_spec_index_from_service.py
+++ b/test/rostest/test_service_discovery/test_spec_index_from_service.py
@@ -16,6 +16,8 @@ class Test(unittest.TestCase):
         si, errors = spec_index_from_service()
         assert not errors
         assert 'minimal_pkg/Minimal' in si.interfaces
+        assert 'minimal_pkg/SpecificMinimal' in si.semantic_interfaces
+        assert 'minimal_pkg/SlowToDie' not in si.interfaces
 
 if __name__ == '__main__':
     import rospy

--- a/test/rostest/test_service_discovery/test_spec_index_from_service.test
+++ b/test/rostest/test_service_discovery/test_spec_index_from_service.test
@@ -2,6 +2,12 @@
   <node pkg="capabilities" name="capability_server" type="capability_server" output="screen" required="true">
     <env name="ROS_PACKAGE_PATH"
          value="$(find capabilities)/test/unit/discovery_workspaces/minimal:$(env ROS_PACKAGE_PATH)" />
+    <rosparam param="whitelist">
+        - minimal_pkg/Minimal
+        - minimal_pkg/SpecificMinimal
+    </rosparam>
+    <rosparam param="blacklist">
+    </rosparam>
   </node>
   <test test-name="spec_index_from_service" pkg="capabilities" type="test_spec_index_from_service.py" launch-prefix="$(find capabilities)/test/run_coverage run --source=$(find capabilities)/src/capabilities --append "/>
 </launch>


### PR DESCRIPTION
To ensure GetCapabilitySpecs service returns the filtered specs.