### PR TITLE
Bump CMake version to avoid CMP0048 warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "2.7"
 # command to install dependencies
 install:
-  - pip install nose coverage pep8 PyYAML catkin_pkg rospkg empy python-coveralls --use-mirrors
+  - pip install nose coverage pep8 PyYAML catkin_pkg rospkg empy python-coveralls
   - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
+dist: bionic
 language: python
 python:
   - "2.7"
 # command to install dependencies
 install:
   - pip install nose coverage pep8 PyYAML catkin_pkg rospkg empy python-coveralls
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu bionic main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
   - sudo apt-get install python-rosdep
   - sudo `which rosdep` init
   - rosdep update
-  - rosdep install --from-paths ./ --rosdistro hydro -y
-# Install image_proc to get a nodelet instaleld as a workaround to https://github.com/ros/pluginlib/pull/22
-  - sudo apt-get install ros-hydro-image-proc
+  - rosdep install --from-paths ./ --rosdistro melodic -y
 # command to run tests
 script:
-  - source /opt/ros/hydro/setup.bash
+  - source /opt/ros/melodic/setup.bash
   - make coverage
   - catkin_test_results /tmp/capabilities_build/build/test_results
 notifications:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(capabilities)
 
 find_package(catkin REQUIRED COMPONENTS message_generation std_msgs std_srvs)

--- a/test/run_coverage
+++ b/test/run_coverage
@@ -3,9 +3,9 @@
 import sys
 
 try:
-    from coverage import main
+    from coverage.cmdline import main
 except ImportError as exc:
-    print("Error: failed to run coverage: {0}".format(exc))
+    sys.exit("Error: failed to run coverage: {0}".format(exc))
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
This bumps the minimum CMake version to 3.0.2, which is the [minimum supported by ROS Kinetic](https://www.ros.org/reps/rep-0003.html#kinetic-kame-may-2016-may-2021) and new enough to default to the NEW behavior of [CMP0048](https://cmake.org/cmake/help/v3.0/policy/CMP0048.html). This avoids a CMake warning when building and testing this package in Debian Buster and Ubuntu Focal.

ros/catkin#1052