### PR TITLE
support python3 by updating to package.xml format 3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="3">
   <name>capabilities</name>
   <version>0.3.0</version>
   <description>
@@ -24,19 +24,25 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
 
-  <run_depend>bondpy</run_depend>
-  <run_depend>message_runtime</run_depend>
-  <run_depend>nodelet</run_depend>
-  <run_depend>python-yaml</run_depend>
-  <run_depend>roslaunch</run_depend>
-  <run_depend>rospy</run_depend>
-  <run_depend>std_msgs</run_depend>
-  <run_depend>std_srvs</run_depend>
+  <build_export_depend>message_runtime</build_export_depend>
+
+  <exec_depend>bondpy</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>nodelet</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</exec_depend>
+  <exec_depend>roslaunch</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
 
   <test_depend>geometry_msgs</test_depend>
-  <test_depend>python-coverage</test_depend>
-  <test_depend>python-mock</test_depend>
-  <test_depend>python-pep8</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-coverage</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-coverage</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-mock</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-mock</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-pep8</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-pep8</test_depend>
   <test_depend>rosservice</test_depend>
 
   <export>


### PR DESCRIPTION
Using conditional dependencies in format 3, depend on the python3 version of things in focal/noetic.

@sloretz will you review this since you've seen several related cases?