### PR TITLE
Use itertools.chain to fix python3 test failure

### DIFF
--- a/src/capabilities/discovery.py
+++ b/src/capabilities/discovery.py
@@ -88,6 +88,7 @@ You can use this API as follows, (examples assume use of the
 
 """
 
+import itertools
 import os
 
 from catkin_pkg.packages import find_packages
@@ -434,7 +435,8 @@ class SpecIndex(object):
         :returns: list of the names for all specs of all types
         :rtype: :py:obj:`list` (:py:obj:`str`)
         """
-        return self.interfaces.keys() + self.semantic_interfaces.keys() + self.providers.keys()
+        return list(itertools.chain(
+            self.interfaces.keys(), self.semantic_interfaces.keys(), self.providers.keys())
 
     @property
     def specs(self):

--- a/src/capabilities/discovery.py
+++ b/src/capabilities/discovery.py
@@ -436,7 +436,7 @@ class SpecIndex(object):
         :rtype: :py:obj:`list` (:py:obj:`str`)
         """
         return list(itertools.chain(
-            self.interfaces.keys(), self.semantic_interfaces.keys(), self.providers.keys())
+            self.interfaces.keys(), self.semantic_interfaces.keys(), self.providers.keys()))
 
     @property
     def specs(self):


### PR DESCRIPTION
I'd expect this to fix a few of the test failures in http://build.ros.org/job/Ndev__capabilities__ubuntu_focal_amd64/1/


```
======================================================================
ERROR: unit.test_discovery.test_load_minimal
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/tmp/ws/src/capabilities/test/unit/test_discovery.py", line 18, in test_load_minimal
    spec_index, errors = spec_index_from_spec_file_index(spec_file_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 294, in spec_index_from_spec_file_index
    return _spec_loader(spec_file_index, {
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 231, in _spec_loader
    spec_thing_loaders['capability_interface'](thing, package_name, spec_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 284, in capability_interface_loader
    spec_index.add_interface(interface, path, package_name)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 329, in add_interface
    if interface_name in self.names:
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 437, in names
    return self.interfaces.keys() + self.semantic_interfaces.keys() + self.providers.keys()
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
-------------------- >> begin captured stdout << ---------------------
Testing minimal workspace

--------------------- >> end captured stdout << ----------------------

======================================================================
ERROR: unit.test_discovery.test_load_invalid_specs
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/tmp/ws/src/capabilities/test/unit/test_discovery.py", line 40, in test_load_invalid_specs
    spec_index, errors = spec_index_from_spec_file_index(spec_file_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 294, in spec_index_from_spec_file_index
    return _spec_loader(spec_file_index, {
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 231, in _spec_loader
    spec_thing_loaders['capability_interface'](thing, package_name, spec_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 284, in capability_interface_loader
    spec_index.add_interface(interface, path, package_name)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 329, in add_interface
    if interface_name in self.names:
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 437, in names
    return self.interfaces.keys() + self.semantic_interfaces.keys() + self.providers.keys()
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
-------------------- >> begin captured stdout << ---------------------
Testing invalid_specs workspace

--------------------- >> end captured stdout << ----------------------

======================================================================
ERROR: unit.test_discovery.test_load_missing_interface
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/tmp/ws/src/capabilities/test/unit/test_discovery.py", line 48, in test_load_missing_interface
    spec_index, errors = spec_index_from_spec_file_index(spec_file_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 294, in spec_index_from_spec_file_index
    return _spec_loader(spec_file_index, {
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 231, in _spec_loader
    spec_thing_loaders['capability_interface'](thing, package_name, spec_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 284, in capability_interface_loader
    spec_index.add_interface(interface, path, package_name)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 329, in add_interface
    if interface_name in self.names:
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 437, in names
    return self.interfaces.keys() + self.semantic_interfaces.keys() + self.providers.keys()
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
-------------------- >> begin captured stdout << ---------------------
Testing missing_interface workspace

--------------------- >> end captured stdout << ----------------------

======================================================================
ERROR: unit.test_discovery.test_load_duplicate_names
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/tmp/ws/src/capabilities/test/unit/test_discovery.py", line 56, in test_load_duplicate_names
    spec_index, errors = spec_index_from_spec_file_index(spec_file_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 294, in spec_index_from_spec_file_index
    return _spec_loader(spec_file_index, {
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 231, in _spec_loader
    spec_thing_loaders['capability_interface'](thing, package_name, spec_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 284, in capability_interface_loader
    spec_index.add_interface(interface, path, package_name)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 329, in add_interface
    if interface_name in self.names:
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 437, in names
    return self.interfaces.keys() + self.semantic_interfaces.keys() + self.providers.keys()
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
-------------------- >> begin captured stdout << ---------------------
Testing duplicate_names workspace

--------------------- >> end captured stdout << ----------------------

======================================================================
ERROR: unit.test_discovery.test_load_duplicate_names_semantic
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/tmp/ws/src/capabilities/test/unit/test_discovery.py", line 66, in test_load_duplicate_names_semantic
    spec_index, errors = spec_index_from_spec_file_index(spec_file_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 294, in spec_index_from_spec_file_index
    return _spec_loader(spec_file_index, {
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 231, in _spec_loader
    spec_thing_loaders['capability_interface'](thing, package_name, spec_index)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 284, in capability_interface_loader
    spec_index.add_interface(interface, path, package_name)
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 329, in add_interface
    if interface_name in self.names:
  File "/tmp/ws/src/capabilities/src/capabilities/discovery.py", line 437, in names
    return self.interfaces.keys() + self.semantic_interfaces.keys() + self.providers.keys()
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'
-------------------- >> begin captured stdout << ---------------------
Testing duplicate_names_semantic workspace

--------------------- >> end captured stdout << ----------------------
```