### PR TITLE
Switch from pep8 to pycodestyle and actually run it

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,8 +41,8 @@
   <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-coverage</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 2">python-mock</test_depend>
   <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-mock</test_depend>
-  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-pep8</test_depend>
-  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-pep8</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 2">python-pycodestyle</test_depend>
+  <test_depend condition="$ROS_PYTHON_VERSION == 3">python3-pycodestyle</test_depend>
   <test_depend>rosservice</test_depend>
 
   <export>

--- a/scripts/capability_server
+++ b/scripts/capability_server
@@ -2,7 +2,7 @@
 
 import sys
 
-#### HACK until rospy uses the threading module rather than the thread module
+# HACK until rospy uses the threading module rather than the thread module #
 import threading
 
 from rospy.impl import tcpros_service
@@ -18,10 +18,11 @@ class MyThread(object):
         t.start()
         self.__threads_objs.append(t)
 
-tcpros_service._thread = MyThread()
-#### END HACK
 
-from capabilities.server import main
+tcpros_service._thread = MyThread()
+# END HACK #
+
+from capabilities.server import main  # noqa: E402 # REMOVE NOQA WITH HACK
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/src/capabilities/discovery.py
+++ b/src/capabilities/discovery.py
@@ -206,7 +206,7 @@ def spec_file_index_from_package_index(package_index):
                 spec_file_index[package_name][tag].append(spec_file_path)
         # Prune packages with no specs
         if (
-                not spec_file_index[package_name]['capability_interface']
+            not spec_file_index[package_name]['capability_interface']
             and not spec_file_index[package_name]['capability_provider']
             and not spec_file_index[package_name]['semantic_capability_interface']
         ):

--- a/src/capabilities/launch_manager.py
+++ b/src/capabilities/launch_manager.py
@@ -75,6 +75,7 @@ def which(program):
                 return exe_file
     return None
 
+
 _this_dir = os.path.dirname(__file__)
 _placeholder_script = os.path.join(_this_dir, 'placeholder_script')
 _nodelet_manager_launch_file = os.path.join(_this_dir, 'capability_server_nodelet_manager.launch')

--- a/src/capabilities/server.py
+++ b/src/capabilities/server.py
@@ -103,9 +103,9 @@ from capabilities.specs.semantic_interface import semantic_capability_interface_
 
 USER_SERVICE_REASON = 'user service call'
 
-## Hack to squelch output from Service call failure ##
+# Hack to squelch output from Service call failure #
 
-from rospy.impl import tcpros_service
+from rospy.impl import tcpros_service  # noqa: E402
 
 
 def custom__handle_request(self, transport, request):  # pragma: no cover
@@ -126,9 +126,10 @@ def custom__handle_request(self, transport, request):  # pragma: no cover
         # rospy.logerr("Error processing request: %s\n%s" % (e, traceback.print_exc()))
         self._write_service_error(transport, "error processing request: %s" % e)
 
+
 tcpros_service.ServiceImpl._handle_request = custom__handle_request
 
-## End hacks ##
+# End hacks #
 
 
 class CapabilityInstance(object):

--- a/src/capabilities/specs/provider.py
+++ b/src/capabilities/specs/provider.py
@@ -187,7 +187,7 @@ def capability_provider_from_dict(spec, file_name='<dict>'):
         capability_provider = CapabilityProvider(name, spec_version, implements, launch_file,
                                                  description, remappings, nodelet_manager)
     except (AssertionError, ValueError) as e:  # Catch remapping errors
-            raise InvalidProvider(str(e), file_name)
+        raise InvalidProvider(str(e), file_name)
     depends_on = spec.get('depends_on', {})
     if isinstance(depends_on, str):
         depends_on = [depends_on]

--- a/test/unit/test_code_quality.py
+++ b/test/unit/test_code_quality.py
@@ -1,12 +1,19 @@
-import pep8
+import pycodestyle
 import os
 
 
-def test_pep8_conformance():
+def test_pycodestyle_conformance():
     """Test source code for PEP8 conformance"""
-    pep8style = pep8.StyleGuide(max_line_length=120)
-    report = pep8style.options.report
+    pycodestyle_style = pycodestyle.StyleGuide(max_line_length=120)
+    pycodestyle_style.verbose = True
+    report = pycodestyle_style.options.report
     report.start()
-    pep8style.input_dir(os.path.normpath(os.path.join(os.path.dirname(__file__), '..', 'src', 'capabilities')))
+    package_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    assert os.path.isdir(package_dir)
+
+    pycodestyle_style.input_dir(os.path.join(package_dir, 'src', 'capabilities'))
+    pycodestyle_style.options.filename = '.*'
+    pycodestyle_style.input_dir(os.path.join(package_dir, 'scripts'))
+
     report.stop()
     assert report.total_errors == 0, "Found '{0}' code style errors (and warnings).".format(report.total_errors)


### PR DESCRIPTION
The pep8 package has been deprecated and replaced by pycodestyle, which claims to be a drop-in replacement.

The code quality tests have actually been broken since 2013 when they were regressed by fbd36868fdb8cc22dfc4b89f4ace475554b486a8. I fixed the test and fixed the pep8 violations that have accumulated since then.